### PR TITLE
Add cdn links for bootstrap assets

### DIFF
--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -12,6 +12,10 @@ $this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Open+San
 $this->headScript()->prependFile($this->assetUrl('js/default.js'));
 $this->headScript()->prependFile($this->assetUrl('js/global.js', 'Omeka'));
 $this->headScript()->prependFile($this->assetUrl('vendor/jquery/jquery.min.js', 'Omeka'));
+$this->headLink()->prependStylesheet('https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css');
+$this->headScript()->prependFile('https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js');
+$this->headScript()->prependFile('https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js');
+
 $this->jsTranslate();
 $this->trigger('view.layout');
 $userBar = $this->userBar();


### PR DESCRIPTION
This closes #10. I looked into using a dependency manager to load the Bootstrap assets, but everything I read indicated that just using the CDN links would be faster because most browsers will already have them cached anyway. 

This might be an issue if we ever run into a situation where bootstrap and Omeka's core UI are expecting different versions of of jQuery. But it seems like much of Omeka's use of jQuery is on the back end anyway. 