### PR TITLE
Add default link color to config

### DIFF
--- a/asset/sass/_screen.scss
+++ b/asset/sass/_screen.scss
@@ -760,7 +760,7 @@ p {
     &:hover{
         box-shadow: 0 0 10px 2px #858585;
         a{
-            color: darken($link, 20%);;
+            color: darken($link, 20%);
         }
 
     }

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -11,7 +11,7 @@ omeka_version_constraint = "^2.1.0"
 elements.accent_color.name = "accent_color"
 elements.accent_color.type = "Omeka\Form\Element\ColorPicker"
 elements.accent_color.options.label = "Main accent color"
-elements.accent_color.options.info = "An accent color to be used on links. The default value is #089494."
+elements.accent_color.options.info = "An accent color to be used on links. The default value is #286090."
 elements.accent_color.attributes.value = "#286090"
 
 elements.nav_depth.name = "nav_depth"

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -12,7 +12,7 @@ elements.accent_color.name = "accent_color"
 elements.accent_color.type = "Omeka\Form\Element\ColorPicker"
 elements.accent_color.options.label = "Main accent color"
 elements.accent_color.options.info = "An accent color to be used on links. The default value is #089494."
-elements.accent_color.attributes.value = "#920b0b"
+elements.accent_color.attributes.value = "#286090"
 
 elements.nav_depth.name = "nav_depth"
 elements.nav_depth.attributes.id = "nav_depth"

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -39,8 +39,11 @@ $userBar = $this->userBar();
             
             a:active,
             a:hover {
-                color: <?php echo $accentColor; ?>;
-                opacity: .75;
+                color: <?php echo darken_color($accentColor, 20); ?>;
+            }
+
+            .toc-card:hover a {
+                color: <?php echo darken_color($accentColor, 20); ?>;
             }
             <?php endif; ?>
         </style>
@@ -82,3 +85,17 @@ $userBar = $this->userBar();
         </footer>
     </body>
 </html>
+<?php
+
+function darken_color( $hex, $percent ) {
+    preg_match('/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i', $hex, $primary_colors);
+    str_replace('%', '', $percent);
+    $color = "#";
+    for($i = 1; $i <= 3; $i++) {
+        $primary_colors[$i] = hexdec($primary_colors[$i]);
+        $primary_colors[$i] = round($primary_colors[$i] * (100-($percent*2))/100);
+        $color .= str_pad(dechex($primary_colors[$i]), 2, '0', STR_PAD_LEFT);
+    }
+
+    return $color;
+}


### PR DESCRIPTION
This is related to #43. The red link color is the default set in the theme config, so the default should be set there as well. For example, if users change a different config setting and hit save, it will also save the default red color for the links. 