### PR TITLE
I60 uiuc

### DIFF
--- a/view/common/block-layout/exhibit-contents.phtml
+++ b/view/common/block-layout/exhibit-contents.phtml
@@ -1,0 +1,30 @@
+<h2 class="toc-card-header">Exhibit Contents</h2>
+<?php
+$exhibits = $this->exhibits;
+
+$iter = 1; // use iter to determine whether the card is on the left or right
+foreach ($exhibits as $page_id => $preview) : ?>
+    <?php if ($iter % 2): // if card is on the left, make a new row?>
+        <div class="row toc-row">
+    <?php endif; ?>
+    <?php
+    ?>
+    <div class="col-md-6">
+        <div class="card toc-card">
+            <div class="panel-heading">
+                <img alt="<?php echo $preview['alt'] ?>" class="card-img-top" src="<?php echo $preview['img_src'] ?>" />
+            </div>
+            <div class="card-body">
+                <h5 class="card-title"><a class="stretched-link" href="<?php echo $preview['url']; ?>"><?php echo $preview['title']; ?></a></h5>
+            </div>
+        </div>
+    </div>
+    <?php if (($iter % 2) == 0): // if card is on the right, close row?>
+        </div>
+    <?php endif;
+    $iter++;
+endforeach;
+?>
+<?php if (($iter % 2) == 0): // if last card is on the left, close row?>
+    </div>
+<?php endif; ?>

--- a/view/common/block-layout/list-of-exhibits.phtml
+++ b/view/common/block-layout/list-of-exhibits.phtml
@@ -1,0 +1,36 @@
+<h2>Mason List of Exhibits: Theme Override View</h2>
+<p>here are page id's based on the depth the user indicated for exhibits</p>
+<p>the other form options (Include all Omeka-s exhibits, Include other sites, team) aren't hooked up to anything yet</p>
+<p>here is the array that is being passed right now</p>
+<?php
+
+$exhibits = array_merge($this->exhibits, $this->siblings);
+
+$iter = 1; // use iter to determine whether the card is on the left or right
+foreach ($exhibits as $page_id => $preview) : ?>
+    <?php if ($iter % 2): // if card is on the left, make a new row?>
+        <div class="row toc-row">
+    <?php endif; ?>
+    <?php
+    $childPageObject = $preview['site_page'];
+
+    ?>
+    <div class="col-md-6">
+        <div class="card toc-card">
+            <div class="panel-heading">
+                <img alt="<?php echo $preview['alt'] ?>" class="card-img-top" src="<?php echo $preview['img_src'] ?>" />
+            </div>
+            <div class="card-body">
+                <h5 class="card-title"><a class="stretched-link" href="<?php echo $preview['url']; ?>"><?php echo $preview['title']; ?></a></h5>
+            </div>
+        </div>
+    </div>
+    <?php if (($iter % 2) == 0): // if card is on the right, close row?>
+        </div>
+    <?php endif;
+    $iter++;
+endforeach;
+?>
+<?php if (($iter % 2) == 0): // if last card is on the left, close row?>
+    </div>
+<?php endif; ?>

--- a/view/common/block-layout/list-of-exhibits.phtml
+++ b/view/common/block-layout/list-of-exhibits.phtml
@@ -1,7 +1,5 @@
-<h2>Mason List of Exhibits: Theme Override View</h2>
-<p>here are page id's based on the depth the user indicated for exhibits</p>
-<p>the other form options (Include all Omeka-s exhibits, Include other sites, team) aren't hooked up to anything yet</p>
-<p>here is the array that is being passed right now</p>
+<h2 class="toc-card-header">List of Exhibits</h2>
+
 <?php
 
 $exhibits = array_merge($this->exhibits, $this->siblings);

--- a/view/omeka/site/page/show.phtml
+++ b/view/omeka/site/page/show.phtml
@@ -51,42 +51,6 @@ if ($activePage):
                 <div class="blocks">
                     <?php echo $this->content; ?>
                 </div>
-
-                <?php if ($activePage): ?>
-                <?php if ($activePage['depth'] == 0): ?>
-                <h2 class="toc-card-header">Exhibit Contents</h2>
-                <?php
-                $children = $activePage['page']->getPages();
-                $iter = 1; // use iter to determine whether the card is on the left or right
-                foreach ($children as $child) : ?>
-                    <?php if ($iter % 2): // if card is on the left, make a new row?>
-                        <div class="row toc-row">
-                    <?php endif; ?>
-                    <?php
-                    $childPageObject = $this->api()->read('site_pages', ["site" => $site->id(),"title" => $child->getLabel()])->getContent();
-                    $pageThumb = getThumbnail($childPageObject, $default_thumb, 'large');
-                    ?>
-                    <div class="col-md-6">
-                        <div class="card toc-card">
-                            <div class="panel-heading">
-                                <img alt="<?php echo $pageThumb['alt'] ?>" class="card-img-top" src="<?php echo $pageThumb['url'] ?>" />
-                            </div>
-                            <div class="card-body">
-                                <h5 class="card-title"><a class="stretched-link" href="<?php echo $child->getHref(); ?>"><?php echo $child->getLabel(); ?></a></h5>
-                            </div>
-                        </div>
-                    </div>
-                    <?php if (($iter % 2) == 0): // if card is on the right, close row?>
-                        </div>
-                    <?php endif;
-                    $iter++;
-                endforeach;
-                ?>
-                <?php if (($iter % 2) == 0): // if last card is on the left, close row?>
-            </div>
-            <?php endif; ?>
-            <?php endif; ?>
-            <?php endif; ?>
         </div>
         <?php $this->trigger('view.show.after'); ?>
         <?php if ($showPagePagination): ?>


### PR DESCRIPTION
Removed the code that detected if this was the root page and then searched for relavent content pages, and replaced with views for the Mason module Exhibit Contents and List of Exhibits site blocks.

In order to test this, you'll need to add/pull the Mason module and add a site block called Exhibit Contents (Mason) at the exhibit root page. If there are more than one exhibit in the site, you can add a Exhibit Contents (Mason) site block for each exhibit homepage/landing page/index page. That site block finds pages relative to the current page where it is placed. 

If there is an index page for all of the exhibits in a site, you can put a List of Exhibits page block on any page and tell it at what depth to find the exhibits. 

Closes #60 
