### PR TITLE
Detect exhibit boundaries 

### DIFF
--- a/view/common/block-layout/table-of-contents.phtml
+++ b/view/common/block-layout/table-of-contents.phtml
@@ -1,4 +1,4 @@
 <div class="toc-block">
-<?php echo $this->navigation($this->subNav)->menu()->renderMenu(null, ['maxDepth' => $this->maxDepth]); ?>
+<?php echo $this->navigation($this->subNav)->menu()->renderMenu(null, ['maxDepth' => $this->maxDepth, 'onlyActiveBranch'=>true]); ?>
 </div>
 

--- a/view/common/site-page-pagination.phtml
+++ b/view/common/site-page-pagination.phtml
@@ -15,16 +15,22 @@ $nav = $page->site()->navigation();
  * go through the navigation and for each page, make an key in the directory where the value is the oldest ancestor
  * of that page.
  */
-function fillDir ($chapter)
+function fillDir ($chapter, $ancestor, $dir)
 {
     foreach ($chapter['links'] as $section):
-        $directory[$section['data']['id']] = $chapter['data']['id'];
+        $dir[$section['data']['id']] = $ancestor;
+        if ($section['links']){
+            $dir = fillDir($section, $ancestor, $dir);
+        }
     endforeach;
+    return $dir;
 }
+
 foreach ($nav as $chapter):
     $directory[$chapter['data']['id']] = $chapter['data']['id'];
-    fillDir($chapter);
+    $directory = fillDir($chapter, $chapter['data']['id'], $directory);
 endforeach;
+
 /*
  * Only show the next or prev page if that page and the current page share the same oldest ancestor, ie they are par of
  * the same chapter/exhibit.

--- a/view/common/site-page-pagination.phtml
+++ b/view/common/site-page-pagination.phtml
@@ -1,10 +1,46 @@
 <?php
+
+
 $translate = $this->plugin('translate');
 $prevText = $translate('Previous Section: ');
 $nextText = $translate('Next Section: ');
 $default_thumb = $this->assetUrl('img/Default_square.png');
+
 ?>
 
+<?php
+$directory = [];
+$nav = $page->site()->navigation();
+/*
+ * go through the navigation and for each page, make an key in the directory where the value is the oldest ancestor
+ * of that page.
+ */
+function fillDir ($chapter)
+{
+    foreach ($chapter['links'] as $section):
+        $directory[$section['data']['id']] = $chapter['data']['id'];
+    endforeach;
+}
+foreach ($nav as $chapter):
+    $directory[$chapter['data']['id']] = $chapter['data']['id'];
+    fillDir($chapter);
+endforeach;
+/*
+ * Only show the next or prev page if that page and the current page share the same oldest ancestor, ie they are par of
+ * the same chapter/exhibit.
+ */
+if ($prevPage){
+    if ($directory[$prevPage->id()]!=$directory[$page->id()]){
+        $prevPage = null;
+    }
+}
+if ($nextPage){
+    if ($directory[$nextPage->id()]!=$directory[$page->id()]){
+        $nextPage = null;
+    }
+}
+
+?>
 
 <?php if ($prevPage || $nextPage): ?>
 


### PR DESCRIPTION
This closes #64 by only showing the current 'chapter' (in Zend/Laminas parlance) in the table of contents, and only showing the next/prev page if that page and the current page are in the same chapter. 

This means that exhibits will have to be organized at the 0-level in the site navigation, rather than just below an index of all exhibits pages. That will require some minor rewrites to the list of exhibits site block.  