### PR TITLE
Also get media from any item type page block

### DIFF
--- a/view/omeka/site/page/show.phtml
+++ b/view/omeka/site/page/show.phtml
@@ -63,24 +63,31 @@ function getThumbnail($page, $default, $size){
     //default thumbnail if the page has no media
     $url = $default;
     $alt = 'Default image for next page when no specific media was found for the page';
-
     //get the first media attachment on the target page
     foreach($page->blocks() as $block){
         if (get_class($block) === 'Omeka\Api\Representation\SitePageBlockRepresentation'){
             if ($block->attachments()){
-                $media = $block->attachments()[0]->media();
-                $url = $media->thumbnailUrl($size);
-
-                if (array_key_exists('o-module-alt-text:alt-text', $media->primaryMedia()->jsonSerialize())
-                    && $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text']
-                ) {
-                    $alt = $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text'];
-                } else {
-                    $alt = 'Thumbnail preview for next page';
+                $media = false;
+                foreach ($block->attachments() as $attachment):
+                    if($attachment->media()){
+                        $media = $block->attachments()[0]->media();
+                    } elseif ($block->attachments()[0]->item()->primaryMedia()){
+                        $media = $block->attachments()[0]->item()->primaryMedia();
+                    }
+                    if ($media){
+                        $url = $media->thumbnailUrl($size);
+                        if (array_key_exists('o-module-alt-text:alt-text', $media->primaryMedia()->jsonSerialize())
+                            && $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text']
+                        ) {
+                            $alt = $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text'];
+                        } else {
+                            $alt = 'Thumbnail preview for next page';
+                        }
+                    break 2;
                 }
-
-                break;
+                endforeach;
             }
+
         }
     }
     return ['url' => $url, 'alt' => $alt];


### PR DESCRIPTION
This closes #93. Okay, on item blocks you need to get the item first and then get the `primaryMedia`. Fixed here for the navigation and also fixed in Mason.